### PR TITLE
add rumbster as a dev dependencies, required to run the test

### DIFF
--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mail'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'rumbster'
 end
 


### PR DESCRIPTION
It wa previously included in the core gemspec.
