### PR TITLE
Added test dependency missing

### DIFF
--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-email'
-  s.version         = '0.1.1'
+  s.version         = '0.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send email when an output is received."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mail'
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'rumbster'
+  s.add_runtime_dependency 'rumbster'
 end
 


### PR DESCRIPTION
Add rumbster as a dependency as it's required by the specs, otherwise the specs are not being executed and fail.