### PR TITLE
Catch and log any mail exception to prevent crashing logstash

### DIFF
--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -3,7 +3,7 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 
 # Send email when an output is received. Alternatively, you may include or
-# exclude the email output execution using conditionals. 
+# exclude the email output execution using conditionals.
 class LogStash::Outputs::Email < LogStash::Outputs::Base
 
   config_name "email"
@@ -18,7 +18,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
 
   # The fully-qualified email address to send the email to.
   #
-  # This field also accepts a comma-separated string of addresses, for example: 
+  # This field also accepts a comma-separated string of addresses, for example:
   # `"me@host.com, you@host.com"`
   #
   # You can also use dynamic fields from the event with the `%{fieldname}` syntax.
@@ -32,7 +32,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
 
   # The fully-qualified email address(es) to include as cc: address(es).
   #
-  # This field also accepts a comma-separated string of addresses, for example: 
+  # This field also accepts a comma-separated string of addresses, for example:
   # `"me@host.com, you@host.com"`
   config :cc, :validate => :string
 
@@ -189,7 +189,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
               eventFieldValues.each do |eventFieldValue|
                 isValid = validateValue(eventFieldValue, value)
                 if isValid # no need to iterate any further
-                  @logger.debug("VALID CONDITION FOUND - ", :eventFieldValue => eventFieldValue, :value => value) 
+                  @logger.debug("VALID CONDITION FOUND - ", :eventFieldValue => eventFieldValue, :value => value)
                   break
                 end
               end # end eventFieldValues.each do
@@ -247,7 +247,12 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
         mail.add_file(fileLocation)
       end # end @attachments.each
       @logger.debug? and @logger.debug("Sending mail with these values : ", :from => mail.from, :to => mail.to, :cc => mail.cc, :subject => mail.subject)
-      mail.deliver!
+      begin
+        mail.deliver!
+      rescue Exception => e
+        @logger.warn("Unhandled exception: ", :from => mail.from, :to => mail.to, :subject => mail.subject)
+      end
+
     end # end if successful
   end # def receive
 


### PR DESCRIPTION
I noticed that if for instance the smtp host is down or cant be reached, the mail command fails and crashes the whole logstash instance. The process is stil active, but all modules and configuration get reinitialized, any input listeners go down to and take a while to come up again.

I fixed this in 1.4.2 for me and its working without probs ever since.
