### PR TITLE
Make sure rumbster properly stops on spec after blocks

### DIFF
--- a/spec/outputs/email_spec.rb
+++ b/spec/outputs/email_spec.rb
@@ -18,6 +18,7 @@ describe "outputs/email" do
 
   after :each do
     rumbster.stop
+    sleep 0.01 until rumbster.stopped?
   end
 
   describe  "use a list of email as mail.to (LOGSTASH-827)" do


### PR DESCRIPTION
rumbster.stop sends a raise to the GServer's thread and returns
imediately. This means the next test might start event though rumbster
hasn't stopped completely. This adds a check to make sure it did.