### PR TITLE
Log error when happen in delivery

### DIFF
--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -249,8 +249,9 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
       @logger.debug? and @logger.debug("Sending mail with these values : ", :from => mail.from, :to => mail.to, :cc => mail.cc, :subject => mail.subject)
       begin
         mail.deliver!
-      rescue Exception => e
+      rescue StandardError => e
         @logger.error("Something happen while delivering an email", :exception => e)
+        @logger.debug? && @logger.debug("Processed event: ", :event => event)
       end
     end # end if successful
   end # def receive

--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -247,7 +247,11 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
         mail.add_file(fileLocation)
       end # end @attachments.each
       @logger.debug? and @logger.debug("Sending mail with these values : ", :from => mail.from, :to => mail.to, :cc => mail.cc, :subject => mail.subject)
-      mail.deliver!
+      begin
+        mail.deliver!
+      rescue Exception => e
+        @logger.error("Something happen while delivering an email", :exception => e)
+      end
     end # end if successful
   end # def receive
 

--- a/spec/outputs/email_spec.rb
+++ b/spec/outputs/email_spec.rb
@@ -5,10 +5,10 @@ require "message_observers"
 
 describe "outputs/email" do
 
-  port = 2525
-  let (:rumbster) { Rumbster.new(port) }
+  let (:port)             { rand(1024..65535) }
+  let (:rumbster)         { Rumbster.new(port) }
   let (:message_observer) { MailMessageObserver.new }
-  plugin = LogStash::Plugin.lookup("output", "email")
+  let(:plugin)            { LogStash::Plugin.lookup("output", "email") }
 
 
   before :each do

--- a/spec/outputs/email_spec.rb
+++ b/spec/outputs/email_spec.rb
@@ -21,75 +21,91 @@ describe "outputs/email" do
     sleep 0.01 until rumbster.stopped?
   end
 
-  describe  "use a list of email as mail.to (LOGSTASH-827)" do
+  describe "send email" do
 
-    it "supports list of emails in to field" do
-      subject = plugin.new("to" => ["email1@host, email2@host"],
-                           "match" => ["mymatch", "dummy_match,ok"],
-                           "options" => ["port", port])
-      subject.register
-      subject.receive(LogStash::Event.new("message" => "hello", "dummy_match" => "ok"))
-      expect(message_observer.messages.size).to eq(1)
-      expect(message_observer.messages[0].to).to eq(["email1@host", "email2@host"])
+    context  "use a list of email as mail.to (LOGSTASH-827)" do
+
+      it "supports list of emails in to field" do
+        subject = plugin.new("to" => ["email1@host, email2@host"],
+                             "match" => ["mymatch", "dummy_match,ok"],
+                             "options" => ["port", port])
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "hello", "dummy_match" => "ok"))
+        expect(message_observer.messages.size).to eq(1)
+        expect(message_observer.messages[0].to).to eq(["email1@host", "email2@host"])
+      end
+
+      it "multiple *to* addresses in a field" do
+        subject = plugin.new("to" => "%{to_addr}",
+                             "match" => ["mymatch", "dummy_match,ok"],
+                             "options" => ["port", port])
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "hello",
+                                            "dummy_match" => "ok",
+                                            "to_addr" => ["email1@host", "email2@host"]))
+        expect(message_observer.messages.size).to eq(1)
+        expect(message_observer.messages[0].to).to eq(["email1@host", "email2@host"])
+      end
     end
 
-    it "multiple *to* addresses in a field" do
-      subject = plugin.new("to" => "%{to_addr}",
-                           "match" => ["mymatch", "dummy_match,ok"],
-                           "options" => ["port", port])
-      subject.register
-      subject.receive(LogStash::Event.new("message" => "hello",
-                                          "dummy_match" => "ok",
-                                          "to_addr" => ["email1@host", "email2@host"]))
-      expect(message_observer.messages.size).to eq(1)
-      expect(message_observer.messages[0].to).to eq(["email1@host", "email2@host"])
+    context  "multi-lined text body (LOGSTASH-841)" do
+      it "handles multiline messages" do
+        subject = plugin.new("to" => "me@host",
+                             "subject" => "Hello World",
+                             "body" => "Line1\\nLine2\\nLine3",
+                             "match" => ["mymatch", "dummy_match,*"],
+                             "options" => ["port", port])
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "hello", "dummy_match" => "ok"))
+        expect(message_observer.messages.size).to eq(1)
+        expect(message_observer.messages[0].subject).to eq("Hello World")
+        expect(message_observer.messages[0].body.raw_source).to eq("Line1\r\nLine2\r\nLine3\r\n")
+      end
     end
-  end
 
-  describe  "multi-lined text body (LOGSTASH-841)" do
-    it "handles multiline messages" do
-      subject = plugin.new("to" => "me@host",
-                           "subject" => "Hello World",
-                           "body" => "Line1\\nLine2\\nLine3",
-                           "match" => ["mymatch", "dummy_match,*"],
-                           "options" => ["port", port])
-      subject.register
-      subject.receive(LogStash::Event.new("message" => "hello", "dummy_match" => "ok"))
-      expect(message_observer.messages.size).to eq(1)
-      expect(message_observer.messages[0].subject).to eq("Hello World")
-      expect(message_observer.messages[0].body.raw_source).to eq("Line1\r\nLine2\r\nLine3\r\n")
+    context  "use nil authenticationType (LOGSTASH-559)" do
+      it "reads messages correctly" do
+        subject = plugin.new("to" => "me@host",
+                             "subject" => "Hello World",
+                             "body" => "Line1\\nLine2\\nLine3",
+                             "match" => ["mymatch", "dummy_match,*"],
+                             "options" => ["port", port, "authenticationType", "nil"])
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "hello", "dummy_match" => "ok"))
+        expect(message_observer.messages.size).to eq(1)
+        expect(message_observer.messages[0].subject).to eq("Hello World")
+        expect(message_observer.messages[0].body.raw_source).to eq("Line1\r\nLine2\r\nLine3\r\n")
+      end
     end
-  end
 
-  describe  "use nil authenticationType (LOGSTASH-559)" do
-    it "reads messages correctly" do
-      subject = plugin.new("to" => "me@host",
-                           "subject" => "Hello World",
-                           "body" => "Line1\\nLine2\\nLine3",
-                           "match" => ["mymatch", "dummy_match,*"],
-                           "options" => ["port", port, "authenticationType", "nil"])
-      subject.register
-      subject.receive(LogStash::Event.new("message" => "hello", "dummy_match" => "ok"))
-      expect(message_observer.messages.size).to eq(1)
-      expect(message_observer.messages[0].subject).to eq("Hello World")
-      expect(message_observer.messages[0].body.raw_source).to eq("Line1\r\nLine2\r\nLine3\r\n")
+    context  "match on source and message (LOGSTASH-826)" do
+      it "reads messages correctly" do
+        subject = plugin.new("to" => "me@host",
+                             "subject" => "Hello World",
+                             "body" => "Mail body",
+                             "match" => [ "messageAndSourceMatch", "message,*hello,,and,type,*generator"],
+                             "options" => ["port", port, "authenticationType", "nil"])
+        subject.register
+        subject.receive(LogStash::Event.new("message" => "hello world", "type" => "generator"))
+        expect(message_observer.messages.size).to eq(1)
+        expect(message_observer.messages[0].subject).to eq("Hello World")
+        expect(message_observer.messages[0].body.raw_source).to eq("Mail body\r\n")
+      end
     end
-  end
 
-  describe  "match on source and message (LOGSTASH-826)" do
-    it "reads messages correctly" do
-      subject = plugin.new("to" => "me@host",
-                           "subject" => "Hello World",
-                           "body" => "Mail body",
-                           "match" => [ "messageAndSourceMatch", "message,*hello,,and,type,*generator"],
-                           "options" => ["port", port, "authenticationType", "nil"])
-      subject.register
-      subject.receive(LogStash::Event.new("message" => "hello world", "type" => "generator"))
-      expect(message_observer.messages.size).to eq(1)
-      expect(message_observer.messages[0].subject).to eq("Hello World")
-      expect(message_observer.messages[0].body.raw_source).to eq("Mail body\r\n")
+    context "having no connection to the email server" do
+
+      subject     { plugin.new("to" => "me@host") }
+      let(:event) { LogStash::Event.new("message" => "hello world") }
+
+      before(:each) do
+        subject.register
+      end
+
+      it "should send without throwing an error" do
+        expect { subject.receive(event) }.not_to raise_error
+      end
     end
+
   end
 end
-
-


### PR DESCRIPTION
This PR fixes some issues by logging when something goes wrong during message delivery, like this when something happen you can grasp a log line internally or in your logfile and not having logstash to crash.

Fixes #26 and #7