### PR TITLE
Add an specific exim delivery_method request

### DIFF
--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -126,6 +126,10 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
       Mail.defaults do
         delivery_method :sendmail
       end
+    elsif @via == 'exim'
+      Mail.defaults do
+        delivery_method :exim, :location => options.fetch("location", "/usr/bin/exim")
+      end
     else
       Mail.defaults do
         delivery_method :@via, options


### PR DESCRIPTION
Adds an specific exim delivery method with the intention to provide a fix for #21 

helping out testing this in real life with a working exim instance would be nice.
