### PR TITLE
Lock mail to 2.6.3 which doesn't rely on ruby 2.0 and rubygems 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 3.0.4
+  - Set the version of Mail to 2.6.3, since 2.6.4 has a dependency incompatible with jruby see https://github.com/elastic/logstash/issues/4883
+  
 # 3.0.3
   - New dependency requirements for logstash-core for the 5.0 release
-## 3.0.0
+
+# 3.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-email'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send email when an output is received."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 6.0.0.alpha1"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
 
-  s.add_runtime_dependency 'mail', '>= 2.6.3', '~> 2.6.0'
+  s.add_runtime_dependency 'mail', '2.6.3'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rumbster'


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/4883