### PR TITLE
Bump deps for mime types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.3
+  - Properly constrain mime types deps to be < 3.0 due to ruby 2.0+ requirement
+  - Uncap mail gem deps to play nicely with other plugins
+
 ## 4.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-email'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send email when an output is received."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,9 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'mail', '2.6.3'
+  s.add_runtime_dependency 'mail', '~> 2.6.3'
+  # mime-types >= 3 require ruby 2.0 support
+  s.add_runtime_dependency 'mime-types', '< 3'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rumbster'


### PR DESCRIPTION
Currently this can't be installed on the 5.x series due to gem incompatibilities. This PR fixes that.

Requires a jruby to be set to `JRUBY_OPTS=--2.0`

Relevant discuss: JRUBY_OPTS --2.0