### PR TITLE
[Docs] Rewrite description of the 'domain' option

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -139,7 +139,9 @@ Run the mail relay in debug mode
   * Value type is <<string,string>>
   * Default value is `"localhost"`
 
-Domain used to send the email messages
+The HELO/EHLO domain name used in the greeting message when connecting
+to a remote SMTP server. Some servers require this name to match the
+actual hostname of the connecting client.
 
 [id="plugins-{type}s-{plugin}-from"]
 ===== `from` 

--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -56,7 +56,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
   # Port used to communicate with the mail server
   config :port, :validate => :number, :default => 25
 
-  # Domain used to send the email messages
+  # HELO/EHLO domain name
   config :domain, :validate => :string, :default => "localhost"
 
   # Username to authenticate with the server


### PR DESCRIPTION
Since "domain" can have a number of meanings in the world of SMTP the previous description made absolutely no sense except possibly to those intimately familiar with Ruby's Net::SMTP library.