### PR TITLE
Use example.com in example email addresses and default values

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -29,11 +29,11 @@ exclude the email output execution using conditionals.
 output {
   if "shouldmail" in [tags] {
     email {
-      to => 'technical@logstash.net'
-      from => 'monitor@logstash.net'
+      to => 'technical@example.com'
+      from => 'monitor@example.com'
       subject => 'Alert - %{title}'
       body => "Tags: %{tags}\\n\\Content:\\n%{message}"
-      domain => 'mail.logstash.net'
+      domain => 'mail.example.com'
       port => 25
     }
   }
@@ -114,7 +114,7 @@ Body for the email - plain text only.
 The fully-qualified email address(es) to include as cc: address(es).
 
 This field also accepts a comma-separated string of addresses, for example:
-`"me@host.com, you@host.com"`
+`"me@example.com, you@example.com"`
 
 [id="plugins-{type}s-{plugin}-contenttype"]
 ===== `contenttype` 
@@ -145,7 +145,7 @@ Domain used to send the email messages
 ===== `from` 
 
   * Value type is <<string,string>>
-  * Default value is `"logstash.alert@nowhere.com"`
+  * Default value is `"logstash.alert@example.com"`
 
 The fully-qualified email address for the From: field in the email.
 
@@ -199,7 +199,7 @@ Subject: for the email.
 The fully-qualified email address to send the email to.
 
 This field also accepts a comma-separated string of addresses, for example:
-`"me@host.com, you@host.com"`
+`"me@example.com, you@example.com"`
 
 You can also use dynamic fields from the event with the `%{fieldname}` syntax.
 

--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -6,11 +6,11 @@
 # output {
 #   if "shouldmail" in [tags] {
 #     email {
-#       to => 'technical@logstash.net'
-#       from => 'monitor@logstash.net'
+#       to => 'technical@example.com'
+#       from => 'monitor@example.com'
 #       subject => 'Alert - %{title}'
 #       body => "Tags: %{tags}\\n\\Content:\\n%{message}"
-#       domain => 'mail.logstash.net'
+#       domain => 'mail.example.com'
 #       port => 25
 #     }
 #   }
@@ -30,13 +30,13 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
   # The fully-qualified email address to send the email to.
   #
   # This field also accepts a comma-separated string of addresses, for example:
-  # `"me@host.com, you@host.com"`
+  # `"me@example.com, you@example.com"`
   #
   # You can also use dynamic fields from the event with the `%{fieldname}` syntax.
   config :to, :validate => :string, :required => true
 
   # The fully-qualified email address for the From: field in the email.
-  config :from, :validate => :string, :default => "logstash.alert@nowhere.com"
+  config :from, :validate => :string, :default => "logstash.alert@example.com"
 
   # The fully qualified email address for the Reply-To: field.
   config :replyto, :validate => :string
@@ -44,7 +44,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
   # The fully-qualified email address(es) to include as cc: address(es).
   #
   # This field also accepts a comma-separated string of addresses, for example:
-  # `"me@host.com, you@host.com"`
+  # `"me@example.com, you@example.com"`
   config :cc, :validate => :string
 
   # How Logstash should send the email, either via SMTP or by invoking sendmail.


### PR DESCRIPTION
There are a number of domains specifically meant for examples and similar bogus values, so let's use them instead of risking being a disturbance for the people who own the real domains used in our examples and default values.

We change the default value of the From address (the `from` option) which theoretically could cause problems for users who somehow have managed to rely on the default being logstash.alert@nowhere.com.