### PR TITLE
Fix tests by adding the gserver gem into Gemfile's test group

### DIFF
--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rumbster'
   s.add_development_dependency 'logstash-input-generator'
+  s.add_development_dependency 'gserver'
 
 end
 


### PR DESCRIPTION
The tests aren't passing since the switch from jruby 1.7 to jruby 9. This is mainly because the `gserver` lib is now a gem.

I added it only to the gemfile test group since it's only used for testing purposes.