### PR TITLE
Fix warning on redefined key

### DIFF
--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -125,7 +125,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
   def receive(event)
 
 
-      @logger.debug? and @logger.debug("Creating mail with these settings : ", :via => @via, :options => @options, :from => @from, :to => @to, :cc => @cc, :subject => @subject, :body => @body, :content_type => @contenttype, :htmlbody => @htmlbody, :attachments => @attachments, :to => to, :to => to)
+      @logger.debug? and @logger.debug("Creating mail with these settings : ", :via => @via, :options => @options, :from => @from, :to => @to, :cc => @cc, :subject => @subject, :body => @body, :content_type => @contenttype, :htmlbody => @htmlbody, :attachments => @attachments)
       formatedSubject = event.sprintf(@subject)
       formattedBody = event.sprintf(@body)
       formattedHtmlBody = event.sprintf(@htmlbody)


### PR DESCRIPTION
Currently on 6.0.1 there is a warning when using this filter on a key that is already defined.

This PR fixes it.  #49 fixes it the tests so they won't pass now. 