### PR TITLE
Change `password` configs type to `Password`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.2
+  - Change `password` config type to `Password` to prevent leaks in debug logs [#65](https://github.com/logstash-plugins/logstash-output-email/pull/65)
+
 ## 4.1.1
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -61,7 +61,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-domain>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-from>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-htmlbody>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-password>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-replyto>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-subject>> |<<string,string>>|No
@@ -176,7 +176,7 @@ HTML Body for the email, which may contain HTML markup.
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password` 
 
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Password to authenticate with the server

--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -126,7 +126,9 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
       end
     end # @via tests
     @htmlTemplate = File.open(@template_file, "r").read unless @template_file.nil?
-    @logger.debug("Email Output Registered!", :config => options, :via => @via)
+    log_options = options.clone
+    log_options[:password] = '<password>'
+    @logger.debug("Email Output Registered!", :config => log_options, :via => @via)
   end # def register
 
   public

--- a/lib/logstash/outputs/email.rb
+++ b/lib/logstash/outputs/email.rb
@@ -66,7 +66,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
   config :username, :validate => :string
 
   # Password to authenticate with the server
-  config :password, :validate => :string
+  config :password, :validate => :password
 
   # Authentication method used when identifying with the server
   config :authentication, :validate => :string
@@ -106,7 +106,7 @@ class LogStash::Outputs::Email < LogStash::Outputs::Base
       :port                 => @port,
       :domain               => @domain,
       :user_name            => @username,
-      :password             => @password,
+      :password             => @password.nil? ? nil : @password.value,
       :authentication       => @authentication,
       :enable_starttls_auto => @use_tls,
       :debug                => @debug

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-email'
-  s.version         = '4.1.1'
+  s.version         = '4.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends email to a specified address when output is received"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/email_spec.rb
+++ b/spec/outputs/email_spec.rb
@@ -105,4 +105,17 @@ describe "outputs/email" do
       end
     end
   end
+
+  describe "debugging `password`" do
+
+    it "should not show origin value" do
+      subject = plugin.new("to" => ["email1@host, email2@host"],
+                           "port" => port,
+                           "username" => "email_user",
+                           "password" => "$ecre&-key")
+
+      expect(subject.logger).to receive(:debug).with('<password>')
+      subject.logger.send(:debug, subject.password.to_s)
+    end
+  end
 end


### PR DESCRIPTION
### Description
This PR ensures to protect the `password` from leaks in the debug logs.

- Closes #64 

### Test
```
# config
input {
  stdin {}
}
output {
    email {
      to => 'technical@example.com'
      from => 'monitor@example.com'
      subject => 'Alert - %{title}'
      body => "Tags:"
      template_file => "/tmp/email_template.mustache"
      domain => 'mail.example.com'
      port => 25
    }
}
```

```
# Log before change
    [2022-12-01T18:12:18,435][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@password = "super-secret"
    [2022-12-01T18:12:18,435][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@port = 25
    [2022-12-01T18:12:18,435][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@subject = "Alert - %{title}"
    [2022-12-01T18:12:18,435][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@domain = "mail.example.com"
    [2022-12-01T18:12:18,435][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@from = "monitor@example.com"
    [2022-12-01T18:12:18,435][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@to = "technical@example.com"

# Log after change
    [2022-12-01T18:20:07,714][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@password = <password>
    [2022-12-01T18:20:07,714][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@port = 25
    [2022-12-01T18:20:07,714][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@subject = "Alert - %{title}"
    [2022-12-01T18:20:07,714][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@domain = "mail.example.com"
    [2022-12-01T18:20:07,714][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@from = "monitor@example.com"
    [2022-12-01T18:20:07,714][DEBUG][logstash.outputs.email   ] config LogStash::Outputs::Email/@to = "technical@example.com"
```