### PR TITLE
Switch mime-type version dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.3
+ - Fix: updates gem depencney to require mime-type at least version 3 [#66](https://github.com/logstash-plugins/logstash-output-email/pull/66)
+
 ## 4.1.2
   - Change `password` config type to `Password` to prevent leaks in debug logs [#65](https://github.com/logstash-plugins/logstash-output-email/pull/65)
 

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'mail', '~> 2.6.3'
+  s.add_runtime_dependency 'net-smtp'
   # mime-types >= 3 require ruby 2.0 support
-  s.add_runtime_dependency 'mime-types', '< 3'
+  s.add_runtime_dependency 'mime-types', '>= 3' # < 3 uses numbered parameter which is deprecated
 
   s.add_runtime_dependency 'mustache', '>= 0.99.8'
 

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-email'
-  s.version         = '4.1.2'
+  s.version         = '4.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends email to a specified address when output is received"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Switch an version binding for `mime-type` from strict `<3` to `>= 3`

Fixes #66