### PR TITLE
Upgrade email dependency to fix the Ruby net-smtp load regression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.3
+  - Upgrade `email` dependency so that supports Ruby 3.1. This also fixes the `net-smtp` load regression [#69](https://github.com/logstash-plugins/logstash-output-email/pull/69)
+
 ## 4.1.2
   - Change `password` config type to `Password` to prevent leaks in debug logs [#65](https://github.com/logstash-plugins/logstash-output-email/pull/65)
 
@@ -6,7 +9,7 @@
 
 ## 4.1.0
   - Update gemspec summary
-  - Add bcc suport #55
+  - Add bcc support #55
   - Add mustache templating #51
 
 ## 4.0.6

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-email'
-  s.version         = '4.1.2'
+  s.version         = '4.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends email to a specified address when output is received"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.require_paths = ["lib"]
 
   # Files
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'mail', '~> 2.6.3'
+  s.add_runtime_dependency 'mail', '~> 2.8'
+
   # mime-types >= 3 require ruby 2.0 support
   s.add_runtime_dependency 'mime-types', '< 3'
 

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mail', '~> 2.8'
 
   # mime-types >= 3 require ruby 2.0 support
-  s.add_runtime_dependency 'mime-types', '< 3'
+  s.add_runtime_dependency 'mime-types', '>= 3' # < 3 uses numbered parameter which is deprecated
 
   s.add_runtime_dependency 'mustache', '>= 0.99.8'
 

--- a/logstash-output-email.gemspec
+++ b/logstash-output-email.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'mail', '~> 2.8'
 
-  # mime-types >= 3 require ruby 2.0 support
-  s.add_runtime_dependency 'mime-types', '>= 3' # < 3 uses numbered parameter which is deprecated
 
   s.add_runtime_dependency 'mustache', '>= 0.99.8'
 


### PR DESCRIPTION
### Description
`output-email` plugin with  Logstash 8.10+ versions raises a `LoadError: no such file to load -- net/smtp` error.
It is due to ruby 3.1 regression that marks `net-smtp` as a bundled gem: https://github.com/ruby/ruby/pull/4530

### Solution
`output-email` plugin uses `mail` gem and bundled `net-smtp` gem with ruby 3.1 support was added: https://github.com/mikel/mail/commit/d9d8dcc6bae1774a033ad488cea6217db3a3ebf3
So, we need to update `mail` dependency to `2.8.+` versions.

- Closes #68 
- Closes #66